### PR TITLE
Lowercase VCC inputs and outputs. All of the files are lowercase now …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ opt_x86_64
 *.d
 .sconsign.dblite
 *.pexe
+$$tmep$$.ma_
+error.txt

--- a/vcc/compile.c
+++ b/vcc/compile.c
@@ -91,11 +91,11 @@ void err(char *str)
 
          if (!quiet) printf("%s (%d) \n",str,lines);
          if (quiet)
-         {    f=fopen("ERROR.TXT","w");
+         {    f=fopen("error.txt","w");
               fprintf(f,"%s (%d)\n",str,lines);
               fclose(f);
          }
-         remove("$$TMEP$$.MA_");
+         remove("$$tmep$$.ma_");
          exit(-1);
 }
 
@@ -399,7 +399,7 @@ void Expect(char *str)
          if (!strcmp(str,token)) return;
          if (!quiet) printf ("error: %s expected, %s got (%d)", str, &token, lines);
          if (quiet)
-         {    f=fopen("ERROR.TXT","w");
+         {    f=fopen("error.txt","w");
               fprintf(f,"error: %s expected, %s got (%d) \n", str, &token, lines);
               fclose(f);
          }

--- a/vcc/vcc.c
+++ b/vcc/vcc.c
@@ -84,14 +84,14 @@ PreStartupFiles ()
 WriteMagicOutput ()
 { FILE *f;
 
-         f=fopen("MAGIC.VCS","wb");
+         f=fopen("magic.vcs","wb");
          fwrite (&numscripts, 1, 4, f);
          fwrite (&scriptofstbl, 4, numscripts, f);
          fwrite (code, 1, (cpos-code), f);
          fclose (f);
 
-         remove("ERROR.TXT");
-         remove("$$TMEP$$.MA_");
+         remove("error.txt");
+         remove("$$tmep$$.ma_");
 }
 
 // END NEW CODE
@@ -99,27 +99,27 @@ WriteMagicOutput ()
 WriteEffectOutput ()
 { FILE *f;
 
-         f=fopen("EFFECTS.VCS","wb");
+         f=fopen("effects.vcs","wb");
          fwrite (&numscripts, 1, 4, f);
          fwrite (&scriptofstbl, 4, numscripts, f);
          fwrite (code, 1, (cpos-code), f);
          fclose (f);
 
-         remove("ERROR.TXT");
-         remove("$$TMEP$$.MA_");
+         remove("error.txt");
+         remove("$$tmep$$.ma_");
 }
 
 WriteScriptOutput ()
 { FILE *f;
 
-         f=fopen("STARTUP.VCS","wb");
+         f=fopen("startup.vcs","wb");
          fwrite (&numscripts, 1, 4, f);
          fwrite (&scriptofstbl, 4, numscripts, f);
          fwrite (code, 1, (cpos-code), f);
          fclose (f);
 
-         remove("ERROR.TXT");
-         remove("$$TMEP$$.MA_");
+         remove("error.txt");
+         remove("$$tmep$$.ma_");
 }
 
 void WriteOutput ()
@@ -130,7 +130,7 @@ void WriteOutput ()
 
          i = strlen (fname);
          memcpy (strbuf, &fname, i);
-         strcpy(strbuf + i, ".MAP");
+         strcpy(strbuf + i, ".map");
 
          f = fopen (strbuf, "rb+");
          if (f == 0) {
@@ -153,8 +153,8 @@ void WriteOutput ()
          fwrite (code, 1, (cpos-code), f);
          fclose (f);
 
-         remove("ERROR.TXT");
-         remove("$$TMEP$$.MA_");
+         remove("error.txt");
+         remove("$$tmep$$.ma_");
 }
 
 main (int argc, char *argv[])
@@ -181,11 +181,11 @@ main (int argc, char *argv[])
                      for ( i=0; i<100; i++ )
                          fname[i] = strbuf[i];
                     //  strupr (fname);
-                     if (!strcmp(fname,"EFFECTS")) effect=1;
+                     if (!strcmp(fname,"effects")) effect=1;
 // NEW CODE
-                     if (!strcmp(fname,"MAGIC")) magic=1;
+                     if (!strcmp(fname,"magic")) magic=1;
 // END NEW CODE
-                     if (!strcmp(fname,"STARTUP")) scrpt=1;
+                     if (!strcmp(fname,"startup")) scrpt=1;
                      break;
                    }
            default: { printf ("vcc: Too many parameters. \n");


### PR DESCRIPTION
…and Linux is case-sensitive. The uppercase was making it difficult (impossible?) to rebuild and actually load the output of startup.vc, magic.vc, and effects.vc. Lowercase some other stuff for good measure.