### PR TITLE
Fix the v1wasm build on my machine.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -16,7 +16,7 @@ if not emcc:
     sys.exit(1)
 
 def EmscriptenEnvironment():
-    if sys.platform == 'windows':
+    if sys.platform in ('windows', 'win32'):
         env_dict = {
             'path': os.environ['PATH']
         }

--- a/localserver.py
+++ b/localserver.py
@@ -1,5 +1,13 @@
-import SimpleHTTPServer
-import SocketServer
+#!/usr/bin/env python
+try:
+    import http.server as SimpleHTTPServer
+except:
+    import SimpleHTTPServer
+
+try:
+    import socketserver as SocketServer
+except:
+    import SocketServer
 
 PORT = 8000
 
@@ -10,5 +18,5 @@ Handler.extensions_map['.wasm'] = 'application/wasm'
 
 httpd = SocketServer.TCPServer(("", PORT), Handler)
 
-print "serving at port", PORT
+print("serving at port {0}".format(PORT))
 httpd.serve_forever()


### PR DESCRIPTION
- Fix Sconsfile so that it is possible to build v1wasm on Windows -- it seems some versions of Scons identify the platform as 'windows' but others as 'win32', so easiest to just detect both.
- Fix localserver.py to work in both Python 2 + 3 by using aliased imports.

